### PR TITLE
Allow params object

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ const timings = require('timings-client-js');
 const perf = new timings.PUtils('.perftimings.js');
 ```
 
+Alternatively, you can pass an object of the perf timings file contents to declare your perf instantiation.
+```javascript
+const configFileObj = require('../../.perftimings');
+const timings = require('timings-client-js');
+const perf = new timings.PUtils(configFileObj);
+```
+
 With the client initiated, you can now call the different methods from your script. **NOTE:** the methods are Promise based! Use async methods like `.then((response) => {})` to capture the responses!
 
 ### Example script

--- a/src/perf-utils.js
+++ b/src/perf-utils.js
@@ -8,9 +8,13 @@ axios.defaults.headers.post['Content-Type'] = 'application/json';
 /* eslint no-console: ["error", { allow: ["warn", "error"] }] */
 
 class PUtils {
-  constructor(customConfig = null) {
+   constructor(customConfig = null) {
     this.defaultConfig = '../.config_sample.js';
-    this.params = this.fetchParams(customConfig);
+    if( customConfig && ((typeof customConfig ) === 'object')) {
+      this.params = customConfig
+    } else {
+      this.params = this.fetchParams(customConfig);
+    }
   }
 
   post(name, data) {


### PR DESCRIPTION
To use the timings client as a devDependency inside of a cypress project, I want to pass the configuration parameters as an object, rather than a file to 'require' later. The project fails to read the file properly if not predefined.